### PR TITLE
BM-330 Ne pas afficher les emails explicitement

### DIFF
--- a/src/app/feature/user/components/user-info/user-info.component.html
+++ b/src/app/feature/user/components/user-info/user-info.component.html
@@ -9,7 +9,10 @@
     <nz-descriptions-item nzTitle="Prénom" [nzSpan]="2">
       {{ user?.firstname }}
     </nz-descriptions-item>
-    <nz-descriptions-item nzTitle="Email" [nzSpan]="3">
+    <nz-descriptions-item
+      nzTitle="Email"
+      [nzSpan]="3"
+      *ngIf="user?.id === authUser?.id || isAdmin">
       {{ user?.email }}
     </nz-descriptions-item>
     <nz-descriptions-item nzTitle="Inscris depuis le" [nzSpan]="3">

--- a/src/app/feature/user/components/user-list/user-list.component.html
+++ b/src/app/feature/user/components/user-list/user-list.component.html
@@ -9,9 +9,9 @@
             }}</a>
           </h3>
         </nz-list-item-meta-title>
-        <nz-list-item-meta-description>
+        <!--<nz-list-item-meta-description>
           {{ user.email }}
-        </nz-list-item-meta-description>
+        </nz-list-item-meta-description>-->
       </nz-list-item-meta>
       <nz-list-item-extra>
         Inscrit depuis le {{ user.createdTimestamp | date : 'dd/MM/yyyy' }}


### PR DESCRIPTION
The changes add a conditional statement to the user-info component that controls whether or not the email is displayed based on the user's ID and admin status. Additionally, the changes comment out the display of email in the user-list component.