### PR TITLE
chore: Update package version to 2.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binge-mate",
-  "version": "2.0.6",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "binge-mate",
-      "version": "2.0.6",
+      "version": "2.0.10",
       "dependencies": {
         "@angular/animations": "^15.2.8",
         "@angular/cdk": "^15.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binge-mate",
-  "version": "2.0.6",
+  "version": "2.0.10",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --configuration local",


### PR DESCRIPTION
The package-lock.json and package.json files were updated to reflect the new version number of 2.0.10 for the "binge-mate" project.